### PR TITLE
update PrioritizedReplayBuffer

### DIFF
--- a/rljax/buffer/prioritized_buffer.py
+++ b/rljax/buffer/prioritized_buffer.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from rljax.buffer.replay_buffer import ReplayBuffer
-from rljax.buffer.segment_tree import MinTree, SumTree
+from rljax.buffer.segment_tree import MaxTree, SumTree
 
 
 class PrioritizedReplayBuffer(ReplayBuffer):
@@ -23,8 +23,6 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         alpha=0.6,
         beta=0.4,
         beta_steps=10 ** 5,
-        min_pa=0.0,
-        max_pa=1.0,
         eps=0.01,
     ):
         super(PrioritizedReplayBuffer, self).__init__(
@@ -38,8 +36,6 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         self.alpha = alpha
         self.beta = beta
         self.beta_diff = (1.0 - beta) / beta_steps
-        self.min_pa = min_pa
-        self.max_pa = max_pa
         self.eps = eps
         self._cached_idxes = None
 
@@ -47,12 +43,14 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         while tree_size < buffer_size:
             tree_size *= 2
         self.tree_sum = SumTree(tree_size)
-        self.tree_min = MinTree(tree_size)
+        self.tree_max = MaxTree(tree_size)
 
     def _append(self, state, action, reward, next_state, done):
         # Assign max priority when stored for the first time.
-        self.tree_min[self._p] = self.max_pa
-        self.tree_sum[self._p] = self.max_pa
+        max_pa = self.tree_max.reduce(0, self._n)
+        max_pa = max(max_pa, self.eps)
+        self.tree_max[self._p] = max_pa
+        self.tree_sum[self._p] = max_pa
         super()._append(state, action, reward, next_state, done)
 
     def _sample_idx(self, batch_size):
@@ -60,20 +58,20 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         rand = np.random.rand(batch_size) * total_pa
         idxes = [self.tree_sum.find_prefixsum_idx(r) for r in rand]
         self.beta = min(1.0, self.beta + self.beta_diff)
-        return idxes
+        return idxes, total_pa
 
     def sample(self, batch_size):
         assert self._cached_idxes is None, "Update priorities before sampling."
 
-        self._cached_idxes = self._sample_idx(batch_size)
-        weight = self._calculate_weight(self._cached_idxes)
+        self._cached_idxes, total_pa = self._sample_idx(batch_size)
+        weight = self._calculate_weight(self._cached_idxes, total_pa)
         batch = self._sample(self._cached_idxes)
         return weight, batch
 
-    def _calculate_weight(self, idxes):
-        min_pa = self.tree_min.reduce(0, self._n)
-        weight = [(self.tree_sum[i] / min_pa) ** -self.beta for i in idxes]
+    def _calculate_weight(self, idxes, total_pa):
+        weight = [((self.tree_sum[i]/total_pa) * self._n) ** -self.beta for i in idxes]
         weight = np.array(weight, dtype=np.float32)
+        weight = weight/np.max(weight)
         return np.expand_dims(weight, axis=1)
 
     def update_priority(self, abs_td):
@@ -82,9 +80,9 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         pa = np.array(self._calculate_pa(abs_td), dtype=np.float32).flatten()
         for i, idx in enumerate(self._cached_idxes):
             self.tree_sum[idx] = pa[i]
-            self.tree_min[idx] = pa[i]
+            self.tree_max[idx] = pa[i]
         self._cached_idxes = None
 
     @partial(jax.jit, static_argnums=0)
     def _calculate_pa(self, abs_td: jnp.ndarray) -> jnp.ndarray:
-        return jnp.clip((abs_td + self.eps) ** self.alpha, self.min_pa, self.max_pa)
+        return (abs_td + self.eps) ** self.alpha

--- a/rljax/buffer/segment_tree.py
+++ b/rljax/buffer/segment_tree.py
@@ -84,3 +84,11 @@ class MinTree(SegmentTree):
 
     def __init__(self, size):
         super().__init__(size, min, float("inf"))
+
+class MaxTree(SegmentTree):
+    """
+    Max tree.
+    """
+
+    def __init__(self, size):
+        super().__init__(size, max, -float("inf"))

--- a/rljax/buffer/segment_tree.py
+++ b/rljax/buffer/segment_tree.py
@@ -84,11 +84,3 @@ class MinTree(SegmentTree):
 
     def __init__(self, size):
         super().__init__(size, min, float("inf"))
-
-class MaxTree(SegmentTree):
-    """
-    Max tree.
-    """
-
-    def __init__(self, size):
-        super().__init__(size, max, -float("inf"))

--- a/rljax/buffer/segment_tree.py
+++ b/rljax/buffer/segment_tree.py
@@ -76,6 +76,9 @@ class SumTree(SegmentTree):
                 idx = left + 1
         return idx - self._size
 
+    def get_total_sum(self):
+        return self._values[1]
+
 
 class MinTree(SegmentTree):
     """

--- a/tests/buffer/test_prioritized_buffer.py
+++ b/tests/buffer/test_prioritized_buffer.py
@@ -40,8 +40,7 @@ def test_prioritized_buffer(env_id, state_dtype, state_shape, action_dtype, acti
         assert np.isclose(float(buffer.done[i]), done[i]).all()
         assert np.isclose(np.array(buffer.next_state[i]), state[i + 1]).all()
         assert np.isclose(np.array(buffer.next_state[i]), state[i + 1]).all()
-        assert np.isclose(buffer.tree_sum[i], 0.01)
-        assert np.isclose(buffer.tree_max[i], 0.01)
+        assert np.isclose(buffer.tree_sum[i], 1.0)
 
     for i in range(3):
         w, (s, a, r, d, n_s) = buffer.sample(1)
@@ -60,7 +59,6 @@ def test_prioritized_buffer(env_id, state_dtype, state_shape, action_dtype, acti
 
         for i, idx in enumerate(idxes):
             assert np.isclose(buffer.tree_sum[idx], abs_td_target[i, 0])
-            assert np.isclose(buffer.tree_max[idx], abs_td_target[i, 0])
 
 
 def test_calculate_pa():


### PR DESCRIPTION
Hi Toshki Watanabe.

Thanks for making this repository available.

I'm proposing some modifications to the prioritized buffer implementation. I believe that clipping the abs td error in the _calculate_pa function is not the best solution, as it requires adjusting one more parameter, which is max_pa. In some preliminary tests using the FQF algorithm and max_pa = 1 (default value), all abs_td errors were being clipped and so all transactions were given the same priority.

To remove the need to adjust this parameter, I did some modifications to leave it as proposed in [SCHAUL et al., 2015](https://arxiv.org/pdf/1511.05952.pdf). I also made adjustments to the importance sampling function.